### PR TITLE
Adjust buildings height to map with terrain

### DIFF
--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -43,12 +43,6 @@ int main(int argc, const char **argv) {
     flag_int(&aoSamples, "aoSamples", "Number of samples for ambient occlusion");
     flag_parse(argc, argv, "v" "0.1.0", 0);
 
-    if (append && aoBaking) {
-        printf("Can't use options --append and --bakeAO altogether");
-        printf("Those option are currently exclusive");
-        return EXIT_FAILURE;
-    }
-
     struct Params parameters = {&name[0], &apiKey[0], tileX, tileY, tileZ, {offsetX, offsetY},
         (bool)splitMeshes, aoAtlasSize, aoSamples, (bool)aoBaking, (bool)append, (bool)terrain,
         terrainSubdivision, terrainExtrusionScale, (bool)buildings, buildingsExtrusionScale};


### PR DESCRIPTION
Polygon extrusion is now based on:
- polygon height + minimum height sampled on the terrain for lower bound
- polygon height + centroid height sampled on the terrain for higher bound

Polygon plane height is now based on:
- polygon height + centroid height

<img width="1139" alt="screen shot 2016-04-07 at 10 24 25 am" src="https://cloud.githubusercontent.com/assets/7061573/14354426/4574d81a-fcab-11e5-8353-f33cb1a1f91c.png">
