### PR TITLE
Add pedestal (fill underneath geometry)

### DIFF
--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -14,6 +14,7 @@ int main(int argc, const char **argv) {
     int aoBaking = 0;
     int splitMeshes = 0;
     int append = 0;
+    int pedestal = 0;
     int terrain = 0;
     int terrainSubdivision = 64;
     float terrainExtrusionScale = 1.f;
@@ -41,6 +42,7 @@ int main(int argc, const char **argv) {
     flag_int(&buildings, "buildings", "Whether to export building geometry");
     flag_float(&buildingsExtrusionScale, "buildingsExtrusionScale", "Building height scale factor");
     flag_float(&buildingsHeight, "buildingsHeight", "The height at which building should be extruded (if no height data is available)");
+    flag_int(&pedestal, "pedestal", "Build a pedestal when running with terrain option (Useful for 3d printing)");
     flag_int(&terrain, "terrain", "Generate terrain elevation topography");
     flag_int(&terrainSubdivision, "terrainSubdivision", "Terrain mesh subdivision");
     flag_float(&terrainExtrusionScale, "terrainExtrusionScale", "Terrain mesh extrusion scale");
@@ -56,7 +58,12 @@ int main(int argc, const char **argv) {
     struct Params parameters = {&name[0], &apiKey[0], tileX, tileY, tileZ, {offsetX, offsetY},
         (bool)splitMeshes, aoAtlasSize, aoSamples, (bool)aoBaking, (bool)append, (bool)terrain,
         terrainSubdivision, terrainExtrusionScale, (bool)buildings, buildingsExtrusionScale,
-        (bool)roads, roadsHeight, roadsExtrusionWidth, (bool)normals, buildingsHeight};
+        (bool)roads, roadsHeight, roadsExtrusionWidth, (bool)normals, buildingsHeight, pedestal};
+
+    if (!parameters.terrain && parameters.pedestal) {
+        printf("Pedestal parameters can only be given when exporting with terrain (--terrain)\n");
+        return EXIT_FAILURE;
+    }
 
     if (parameters.aoBaking && (parameters.terrain || parameters.roads)) {
         printf("Ambient occlusion baking not yet available when exporting with option --terrain or --roads\n");

--- a/src/cmdline.c
+++ b/src/cmdline.c
@@ -15,6 +15,7 @@ int main(int argc, const char **argv) {
     int splitMeshes = 0;
     int append = 0;
     int pedestal = 0;
+    float pedestalHeight = 0.f;
     int terrain = 0;
     int terrainSubdivision = 64;
     float terrainExtrusionScale = 1.f;
@@ -43,6 +44,7 @@ int main(int argc, const char **argv) {
     flag_float(&buildingsExtrusionScale, "buildingsExtrusionScale", "Building height scale factor");
     flag_float(&buildingsHeight, "buildingsHeight", "The height at which building should be extruded (if no height data is available)");
     flag_int(&pedestal, "pedestal", "Build a pedestal when running with terrain option (Useful for 3d printing)");
+    flag_float(&pedestalHeight, "pedestalHeight", "Pedestal height, can be negative");
     flag_int(&terrain, "terrain", "Generate terrain elevation topography");
     flag_int(&terrainSubdivision, "terrainSubdivision", "Terrain mesh subdivision");
     flag_float(&terrainExtrusionScale, "terrainExtrusionScale", "Terrain mesh extrusion scale");
@@ -58,7 +60,8 @@ int main(int argc, const char **argv) {
     struct Params parameters = {&name[0], &apiKey[0], tileX, tileY, tileZ, {offsetX, offsetY},
         (bool)splitMeshes, aoAtlasSize, aoSamples, (bool)aoBaking, (bool)append, (bool)terrain,
         terrainSubdivision, terrainExtrusionScale, (bool)buildings, buildingsExtrusionScale,
-        (bool)roads, roadsHeight, roadsExtrusionWidth, (bool)normals, buildingsHeight, pedestal};
+        (bool)roads, roadsHeight, roadsExtrusionWidth, (bool)normals, buildingsHeight, pedestal,
+        pedestalHeight};
 
     if (!parameters.terrain && parameters.pedestal) {
         printf("Pedestal parameters can only be given when exporting with terrain (--terrain)\n");

--- a/src/projection.h
+++ b/src/projection.h
@@ -3,6 +3,7 @@
 #include "glm/glm.hpp"
 #include <cmath>
 #include <functional>
+#include <bitset>
 
 #define R_EARTH 6378137.0
 #define PI M_PI
@@ -15,10 +16,19 @@ glm::dvec2 pixelsToMeters(const glm::dvec2 _pix, const int _zoom, double _invTil
 glm::dvec4 tileBounds(int x, int y, int z, double _tileSize);
 glm::dvec2 tileCenter(int x, int y, int z, double _tileSize);
 
+enum Border {
+    right,
+    left,
+    bottom,
+    top,
+};
+
 struct Tile {
     int x;
     int y;
     int z;
+
+    std::bitset<4> borders;
 
     double invScale = 0.0;
     glm::dvec2 tileOrigin;
@@ -32,6 +42,7 @@ struct Tile {
         tileOrigin = glm::dvec2(0.5 * (bounds.x + bounds.z), -0.5 * (bounds.y + bounds.w));
         double scale = 0.5 * glm::abs(bounds.x - bounds.z);
         invScale = 1.0 / scale;
+        borders = 0;
     }
 };
 

--- a/src/vectiler.cpp
+++ b/src/vectiler.cpp
@@ -752,7 +752,25 @@ int vectiler(Params exportParams) {
 
         for (size_t x = startx; x <= endx; ++x) {
             for (size_t y = starty; y <= endy; ++y) {
-                tiles.emplace_back(x, y, exportParams.tilez);
+                Tile t(x, y, exportParams.tilez);
+
+                if (x == startx) {
+                    t.borders.set(Border::left, 1);
+                }
+
+                if (x == endx) {
+                    t.borders.set(Border::right, 1);
+                }
+
+                if (y == starty) {
+                    t.borders.set(Border::top, 1);
+                }
+
+                if (y == endy) {
+                    t.borders.set(Border::bottom, 1);
+                }
+
+                tiles.push_back(t);
             }
         }
     }

--- a/src/vectiler.cpp
+++ b/src/vectiler.cpp
@@ -440,7 +440,8 @@ void buildPedestalPlanes(const Tile& tile,
     std::vector<PolygonVertex>& outVertices,
     std::vector<unsigned int>& outIndices,
     const std::unique_ptr<HeightData>& elevation,
-    unsigned int subdiv)
+    unsigned int subdiv,
+    float pedestalHeight)
 {
     float offset = 1.0 / subdiv;
     int vertexDataOffset = outVertices.size();
@@ -486,9 +487,9 @@ void buildPedestalPlanes(const Tile& tile,
             outVertices.push_back({v0, normalVector});
             v1.z = h1 * tile.invScale;
             outVertices.push_back({v1, normalVector});
-            v0.z = 0.0;
+            v0.z = pedestalHeight * tile.invScale;
             outVertices.push_back({v0, normalVector});
-            v1.z = 0.0;
+            v1.z = pedestalHeight * tile.invScale;
             outVertices.push_back({v1, normalVector});
 
             if (i == Border::right || i == Border::bottom) {
@@ -970,8 +971,12 @@ int vectiler(Params exportParams) {
                     buildPlane(ground->vertices, ground->indices, 2.0, 2.0,
                         exportParams.terrainSubdivision, exportParams.terrainSubdivision, true);
 
+                    for (auto& vertex : ground->vertices) {
+                        vertex.position.z = exportParams.pedestalHeight * tile.invScale;
+                    }
+
                     buildPedestalPlanes(tile, wall->vertices, wall->indices, textureData,
-                        exportParams.terrainSubdivision);
+                        exportParams.terrainSubdivision, exportParams.pedestalHeight);
 
                     ground->offset = offset;
                     meshes.push_back(std::move(ground));

--- a/src/vectiler.h
+++ b/src/vectiler.h
@@ -24,6 +24,7 @@ struct Params {
     bool normals;
     float buildingsHeight;
     int pedestal;
+    float pedestalHeight;
 };
 
 #ifdef __cplusplus

--- a/src/vectiler.h
+++ b/src/vectiler.h
@@ -23,6 +23,7 @@ struct Params {
     float roadsExtrusionWidth;
     bool normals;
     float buildingsHeight;
+    int pedestal;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add pedestal option to fill up underneath geometry when terrain is exported (with a possible height for it).


Export example:
```
./vectiler.out --tilex 5240/5241 --tiley 12674/12675 --tilez 15 --buildingsHeight 45 --buildings 1 --normals 0 --terrain 1 --terrainExtrusionScale 3.2 --pedestal 1 --pedestalHeight -60
```
<img width="668" alt="screen shot 2016-07-21 at 12 37 07 am" src="https://cloud.githubusercontent.com/assets/7061573/17011370/75f0ea74-4edb-11e6-9f57-056653580e22.png">

Also works for wider tile ranges:

<img width="831" alt="screen shot 2016-07-20 at 2 02 47 pm" src="https://cloud.githubusercontent.com/assets/7061573/17011404/ccdd8072-4edb-11e6-99eb-2adc00d38d4a.png">
