### PR TITLE
bugfix, invalid size of terrarium tiles

### DIFF
--- a/src/vectiler.cpp
+++ b/src/vectiler.cpp
@@ -758,7 +758,7 @@ inline std::string vectorTileURL(const Tile& tile, const std::string& apiKey) {
 }
 
 inline std::string terrainURL(const Tile& tile, const std::string& apiKey) {
-    return "https://tile.nextzen.org/tilezen/terrain/v1/256/terrarium/"
+    return "https://tile.nextzen.org/tilezen/terrain/v1/260/terrarium/"
         + std::to_string(tile.z) + "/"
         + std::to_string(tile.x) + "/"
         + std::to_string(tile.y) + ".png?api_key=" + apiKey;


### PR DESCRIPTION
256px terrarium tiles are only available if you use the public S3 dataset.
NextZen's service uses tileZen's Zaloa (https://github.com/tilezen/zaloa) to generate 512px, 260px, and 516px tiles from 256px sources, which contain overlapping data from neighboring tiles.